### PR TITLE
Fix missing import

### DIFF
--- a/docs/part-0-fundamentals/first-launch.md
+++ b/docs/part-0-fundamentals/first-launch.md
@@ -33,6 +33,7 @@ cd ~/quickshell-playground/first-launch
 Now create `shell.qml`:
 
 ```qml
+import QtQuick
 import Quickshell
 
 PanelWindow {
@@ -61,6 +62,7 @@ A small dark panel should appear at the top of your screen with the text "Quicks
 
 Let's break down what each line does:
 
+- `import QtQuick` — provides the standard QML UI types, such as `Text`.
 - `import Quickshell` — makes Quickshell's types available. Without this, `PanelWindow` wouldn't be recognized.
 - `PanelWindow { ... }` — creates a window using the Layer Shell protocol, positioned at the top layer. `PanelWindow` is the primary window type for bars and panels.
 - `width: 400; height: 48` — the window is 400 by 48 pixels.
@@ -74,6 +76,7 @@ Let's break down what each line does:
 Let's add a few more elements to see how the panel responds:
 
 ```qml
+import QtQuick
 import Quickshell
 
 PanelWindow {
@@ -128,7 +131,7 @@ Save and see the hot reload in action. The panel now has a workspace indicator o
 When you ran `quickshell ./`, the following occurred:
 
 1. Quickshell scanned the directory for `shell.qml`
-2. It loaded the QML file and resolved the `import Quickshell` statement
+2. It loaded the QML file and resolved the `QtQuick` and `Quickshell` imports.
 3. It created a `PanelWindow` — this involved:
    - Opening a Wayland connection
    - Creating a `wlr-layer-shell` surface


### PR DESCRIPTION
This PR fixes missing `QtQuick` imports in the documentation examples and updates the accompanying explanations to mention both `QtQuick` and `Quickshell` imports.

## Summary by Sourcery

Document the need to import both QtQuick and Quickshell in the first-launch tutorial examples.

Documentation:
- Update first-launch tutorial code samples to include missing QtQuick imports.
- Clarify the explanation of imports to mention both QtQuick and Quickshell and describe QtQuick’s role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated introductory QML examples to include the required `QtQuick` import.
  * Added explanations for the new import and clarified how both imports are resolved when loading the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->