### PR TITLE
Update objects.md

### DIFF
--- a/docs/part-1-qml/objects.md
+++ b/docs/part-1-qml/objects.md
@@ -145,10 +145,12 @@ Window {
       onClicked: {
         box.color = "#ff6b6b"
         label.text = "Clicked!"
+        clickTimer.start()
       }
     }
 
     Timer {
+      id: clickTimer
       interval: 1000
       running: false
       onTriggered: {


### PR DESCRIPTION
Fix id missing

## Summary by Sourcery

Correct the QML timer example by adding the missing identifier and starting it when the button is clicked.

Bug Fixes:
- Fix the QML timer example so the click handler can start the timer correctly.

Documentation:
- Update the QML objects documentation example with the missing timer identifier and its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the interactive QML example so clicking the box starts a timer.
  - After one second, the timer resets the box color and label text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->